### PR TITLE
Manteniendo el nombre del paquete de emojione

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ brew install imagemagick optipng
 Download the lastest Emoji One ZIP and unzip it
 
 ```
-curl -OL https://github.com/Ranks/emojione/archive/master.zip
+curl -OLJ https://github.com/Ranks/emojione/archive/master.zip
 unzip master.zip
 ```
 


### PR DESCRIPTION
El parámetro -J mantiene el nombre del tarball, en caso de que descarges varios paquetes de github de rama master.